### PR TITLE
Add binary validator methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Added `maybe_bin` and `maybe_bin_range` for binary numbers.
+
 ## [1.1.1] - 2024-01-21
 ### Fixed
 - Fixed a typo in the error message when a value is below the minimum limit.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ strings provided by [clap].
   Validates an unsigned integer value that can be base-10 or base-16.
 * `maybe_hex_range`
   Validates an unsigned integer value that can be base-10 or base-16 within a range.
+* `maybe_bin`
+  Validates an unsigned integer value that can be base-10 or base-2.
+* `maybe_bin_range`
+  Validates an unsigned integer value that can be base-10 or base-2 within a range.
 * `number_range`
   Validate a signed or unsigned integer value.
 * `si_number`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,13 +448,13 @@ where
 {
     const BIN_PREFIX: &str = "0b";
     const BIN_PREFIX_LEN: usize = BIN_PREFIX.len();
-    
+
     let result = if s.starts_with(BIN_PREFIX) {
         T::from_str_radix(&s[BIN_PREFIX_LEN..], 2)
     } else {
         T::from_str_radix(s, 10)
     };
-    
+
     result.map_err(stringify)
 }
 

--- a/tests/maybe_bin.rs
+++ b/tests/maybe_bin.rs
@@ -1,0 +1,42 @@
+use clap_num::maybe_bin;
+
+#[cfg(test)]
+mod basic {
+    use super::*;
+
+    // positive path
+    macro_rules! pos {
+        ($NAME:ident, $VAL:expr, $RESULT:expr) => {
+            #[test]
+            fn $NAME() {
+                assert_eq!(maybe_bin($VAL), Ok($RESULT));
+            }
+        };
+    }
+
+    // negative path
+    macro_rules! neg {
+        ($NAME:ident, $VAL:expr, $RESULT:expr) => {
+            #[test]
+            fn $NAME() {
+                let val: Result<u64, String> = maybe_bin($VAL);
+                assert_eq!(val, Err(String::from($RESULT)));
+            }
+        };
+    }
+
+    pos!(simple, "123", 123u8);
+    pos!(zero_dec, "0", 0u16);
+    pos!(zero_bin, "0b0", 0u16);
+    pos!(one_dec, "1", 1u64);
+    pos!(one_bin, "0b1", 1u64);
+    pos!(leading_zero, "001", 1u64);
+
+    neg!(
+        missing_suffix,
+        "0b",
+        "cannot parse integer from empty string"
+    );
+    neg!(non_bin_digit, "0b12G", "invalid digit found in string");
+}
+

--- a/tests/maybe_bin.rs
+++ b/tests/maybe_bin.rs
@@ -39,4 +39,3 @@ mod basic {
     );
     neg!(non_bin_digit, "0b12G", "invalid digit found in string");
 }
-


### PR DESCRIPTION
This crate is really useful for validating hexadecimal numbers. However, it seemed beneficial to also validate binary literals next to hexadecimals. It seems, that binary literal starters (0b vs 0B) are not used in a case-insensitive way, but this can easily be changed, if necessary.