### PR TITLE
tests: Conditionally compile affected tests using debug_assert

### DIFF
--- a/tests/number_range.rs
+++ b/tests/number_range.rs
@@ -42,6 +42,7 @@ mod basic {
     );
     neg!(nan, "nan", 0, 0, "invalid digit found in string");
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic]
     fn min_max_debug_assert() {


### PR DESCRIPTION
Tests will currently fail with optimized build settings because the expected panic won't be compiled.

https://doc.rust-lang.org/reference/conditional-compilation.html#debug_assertions